### PR TITLE
Update CMake minimum version to 3.10, update nitro for the same reason

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@
 
 project(scorep_cplus_abstraction_plugin)
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/common")
 


### PR DESCRIPTION
CMake stopped supporting CMakeLists.txt files that declare a `cmake_minimum_required(VERSION)` < 3.5 and has announced to deprecate support for CMake < 3.10, so update `cmake_minimum_required(VERSION)` to 3.10.